### PR TITLE
Button does not need to be type=submit

### DIFF
--- a/angular-autodisable.js
+++ b/angular-autodisable.js
@@ -75,7 +75,7 @@
               getLoadingClass(attrs),
               getCallbacks(attrs[CLICK_ATTR]));
       } else if (attrs.hasOwnProperty(SUBMIT_ATTR)) {
-          handler = handlerInstance(element.find('button[type=submit]'),
+          handler = handlerInstance(element.find('button'),
               SUBMIT_EVENT,
               getLoadingClass(attrs),
               getCallbacks(attrs[SUBMIT_ATTR]));


### PR DESCRIPTION
Angular JQLite does not accept attribute finders http://stackoverflow.com/questions/29414773/how-are-they-using-this-angular-jqlite-find-method-to-select-a-element-by-attr

So it simpler to find a button
